### PR TITLE
实现 bitindex 的 SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: elixir
+script: mix test

--- a/README.md
+++ b/README.md
@@ -11,3 +11,29 @@ def deps do
   ]
 end
 ```
+
+## Example
+
+**Bitindex api: get utxos for address**
+
+```elixir
+SvApi.Bitindex.utxos("1L9D9Zv9BFqTQScFJzz8rXiUjnmnGxRBvk")
+```
+
+will get
+```ex
+ [
+    %{
+      "address" => "1L9D9Zv9BFqTQScFJzz8rXiUjnmnGxRBvk",
+      "amount" => 8.88e-6,
+      "confirmations" => 4393,
+      "height" => 574803,
+      "satoshis" => 888,
+      "scriptPubKey" => "76a914d1f7dba524ba2be249981eda3e472170a6e1c3a988ac",
+      "txid" => "db2f3a28b1d9591988ad3e473571ed2bf187efd520b31aafa3c7694de1bd5979",
+      "value" => 888,
+      "vout" => 1
+    },
+    ...
+  ]
+```

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :tesla, adapter: Tesla.Mock

--- a/lib/sv_api/bitindex.ex
+++ b/lib/sv_api/bitindex.ex
@@ -11,9 +11,9 @@ defmodule SvApi.Bitindex do
   def utxos(addr) do
     case get("addrs/utxos?address=#{addr}") do
       {:ok, resp} ->
-        Map.get(resp.body, "data")
+        {:ok, Map.get(resp.body, "data")}
       {:error, msg} ->
-        raise(msg)
+        {:error, msg}
     end
   end
 

--- a/lib/sv_api/bitindex.ex
+++ b/lib/sv_api/bitindex.ex
@@ -17,4 +17,13 @@ defmodule SvApi.Bitindex do
     end
   end
 
+  def broadcast(tx) do
+    case post("/tx/send", %{hex: tx}) do
+      {:ok, resp} ->
+        {:ok, Map.get(resp.body, "message")}
+      {:error, msg} ->
+        {:error, msg}
+    end
+  end
+
 end

--- a/lib/sv_api/bitindex.ex
+++ b/lib/sv_api/bitindex.ex
@@ -1,0 +1,20 @@
+defmodule SvApi.Bitindex do
+  use Tesla
+
+  @api_key "44UFrLxSBgPxt4mibqw9m9voHps7RbgT1j92YE1K7XUKefBPLMiPXq7e5Lrmpp8NWa"
+
+  plug Tesla.Middleware.BaseUrl, "https://api.bitindex.network/api/v2"
+  plug Tesla.Middleware.Headers, [{:api_key, @api_key}]
+  plug Tesla.Middleware.JSON
+
+
+  def utxos(addr) do
+    case get("addrs/utxos?address=#{addr}") do
+      {:ok, resp} ->
+        Map.get(resp.body, "data")
+      {:error, msg} ->
+        raise(msg)
+    end
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,9 @@ defmodule SvApi.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:tesla, "~> 1.2.1"},
+      {:hackney, "~> 1.14.0"},
+      {:jason, ">= 1.0.0"},
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,13 @@
+%{
+  "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "hackney": {:hex, :hackney, "1.14.3", "b5f6f5dcc4f1fba340762738759209e21914516df6be440d85772542d4a5e412", [:rebar3], [{:certifi, "2.4.2", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
+  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
+  "tesla": {:hex, :tesla, "1.2.1", "864783cc27f71dd8c8969163704752476cec0f3a51eb3b06393b3971dc9733ff", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+}

--- a/test/sv_api/bitindex_test.exs
+++ b/test/sv_api/bitindex_test.exs
@@ -19,7 +19,7 @@ defmodule SvApi.BitindexTest do
   @addr "1QL7Qbed9X4qfs89bxyKwqwCV9fioGW4Hg"
 
   test "addrs utxos" do
-    assert utxos = Bitindex.utxos(@addr)
+    assert {:ok, utxos} = Bitindex.utxos(@addr)
     assert Enum.all?(utxos, &is_utxo/1)
   end
 end

--- a/test/sv_api/bitindex_test.exs
+++ b/test/sv_api/bitindex_test.exs
@@ -1,0 +1,25 @@
+defmodule SvApi.BitindexTest do
+  @moduledoc """
+  Bitindex api doc: https://www.bitindex.network/docs.html
+  """
+  use ExUnit.Case
+  alias SvApi.Bitindex
+
+  import Tesla.Mock
+
+  # Determine if it is the utxo format specified in the document
+  defp is_utxo(map) do
+    for k <- ~w(address amount confirmations height satoshis scriptPubKey txid value vout) do
+      Map.has_key?(map, k)
+    end |> Enum.all?(&(&1))
+  end
+
+  # this address has only one utxo, for speeding up response
+  # https://blockchair.com/bitcoin-sv/address/qrl7sf8uzykczlyldqwsg7le35gvhjmzq572s0ewcn
+  @addr "1QL7Qbed9X4qfs89bxyKwqwCV9fioGW4Hg"
+
+  test "addrs utxos" do
+    assert utxos = Bitindex.utxos(@addr)
+    assert Enum.all?(utxos, &is_utxo/1)
+  end
+end

--- a/test/sv_api_test.exs
+++ b/test/sv_api_test.exs
@@ -1,8 +1,4 @@
 defmodule SvApiTest do
   use ExUnit.Case
-  doctest SvApi
 
-  test "greets the world" do
-    assert SvApi.hello() == :world
-  end
 end


### PR DESCRIPTION
 1. SvApi.Bitindex.utxo(addr) 通过 bitindex 的 api 获取到特定地址的 utxo
测试:
1. 针对上述功能的测试